### PR TITLE
Created fragment text replacement for "LastWorkoutHighlights"

### DIFF
--- a/app/src/main/java/com/example/musclenerds/database/TrackedSetDAO.java
+++ b/app/src/main/java/com/example/musclenerds/database/TrackedSetDAO.java
@@ -27,4 +27,7 @@ public interface TrackedSetDAO {
 
     @Query("SELECT * FROM TRACKEDSET WHERE id = :id")
     TrackedSet findById(int id);
+
+    @Query("SELECT * FROM TRACKEDSET WHERE T_ID = :id")
+    List <TrackedSet> findByT_ID(int id);
 }

--- a/app/src/main/java/com/example/musclenerds/database/TrackedWorkoutDAO.java
+++ b/app/src/main/java/com/example/musclenerds/database/TrackedWorkoutDAO.java
@@ -27,4 +27,7 @@ public interface TrackedWorkoutDAO {
 
     @Query("SELECT * FROM TRACKEDWORKOUT WHERE id = :id")
     TrackedWorkout findById(int id);
+
+    @Query("SELECT * FROM TRACKEDWORKOUT ORDER BY DateCompleted DESC")
+    List <TrackedWorkout> getLatest();
 }

--- a/app/src/main/java/com/example/musclenerds/model/TrackedWorkout.java
+++ b/app/src/main/java/com/example/musclenerds/model/TrackedWorkout.java
@@ -3,6 +3,7 @@ package com.example.musclenerds.model;
 import androidx.room.Entity;
 import androidx.room.Ignore;
 import androidx.room.PrimaryKey;
+import java.util.Calendar;
 
 @Entity(tableName = "TRACKEDWORKOUT")
 public class TrackedWorkout {
@@ -48,5 +49,8 @@ public class TrackedWorkout {
 
     public String getDateCompleted() {
         return this.DateCompleted;
+    }
+    public void setDateCompleted(String milliseconds){
+        this.DateCompleted = milliseconds;
     }
 }


### PR DESCRIPTION
Created fragment text replacement for "LastWorkoutHighlights"
Updated TrackedSetDAO, TrackedWorkoutDAO, and TrackedWorkout.java
Created getters and setters needed for text replacement
Test data is hard coded for current time - 100000000 milliseconds.
Test data will need removed to accurately display last workout highlights when database populated. 

To test: 
Ensure that "Last Workout Highlights" title on main page has data underneath (not "Last Workout frag Here!")
Workout should be: Full Body Strength (with description below)
Date/Time will be random per user (based on current time - 100000000 milliseconds)

Below date/time should be exercise data:
Deadlift, 20 weight, 10 reps, 7 difficulty

Data should be aligned left.
![LastWorkoutHighlightsExpected](https://user-images.githubusercontent.com/43657601/115800769-8532fd80-a398-11eb-8705-45139ebea85b.png)
